### PR TITLE
feat(service): switch web framework from Gorilla Mux to httprouter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,9 @@ module github.com/ATMackay/psql-ledger
 go 1.21.6
 
 require (
-	github.com/gorilla/mux v1.8.1
+	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/jackc/pgx/v4 v4.18.1
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
 	github.com/sirupsen/logrus v1.9.3
 	github.com/testcontainers/testcontainers-go v0.27.0
@@ -27,7 +28,6 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-migrate/migrate v3.5.4+incompatible // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.4.0 h1:MtMxsa51/r9yyhkyLsVeVt0B+BGQZzpQiTQ4eHZ8bc4=
 github.com/google/uuid v1.4.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1 h1:i+RDz65UE+mmpjTfyz0MoVTnzeYxroil2G82ki7MGG8=
@@ -121,6 +119,8 @@ github.com/jackc/puddle v0.0.0-20190413234325-e4ced69a3a2b/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.3.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=

--- a/integrationtests/setup.go
+++ b/integrationtests/setup.go
@@ -128,7 +128,7 @@ func executeRequest(methodType, url string, body io.Reader, expectedCode int) (*
 	}
 
 	if g, w := response.StatusCode, expectedCode; g != w {
-		return nil, fmt.Errorf("unexpected response code, want %v got %v", w, g)
+		return response, fmt.Errorf("unexpected response code, want %v got %v", w, g)
 	}
 	return response, nil
 

--- a/service/http.go
+++ b/service/http.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gorilla/mux"
+	"github.com/julienschmidt/httprouter"
 	"github.com/sirupsen/logrus"
 )
 
@@ -20,9 +20,7 @@ type HTTPService struct {
 
 func NewHTTPService(port int, api *API, l *logrus.Entry) HTTPService {
 
-	handler := api.Routes()
-	// User logging middleware
-	handler.Use(logHTTPRequest(l))
+	handler := api.Routes(l)
 
 	return HTTPService{
 		server: &http.Server{
@@ -82,51 +80,53 @@ func (a *API) AddEndpoint(e EndPoint) {
 	a.Endpoints = append(a.Endpoints, e)
 }
 
-func (a *API) Routes() *mux.Router {
-	router := mux.NewRouter()
+func (a *API) Routes(l *logrus.Entry) *httprouter.Router {
+
+	router := httprouter.New()
+
 	for _, e := range a.Endpoints {
-		router.Handle(e.Path, e.Handler).Methods(e.MethodType)
+
+		router.Handler(e.MethodType, e.Path, logHTTPRequest(l, e.Handler))
+
 	}
 	return router
 }
 
 // HTTP logging middleware
 
-// logHTTPRequest surfaces low level request/response data from the http server.
-func logHTTPRequest(entry *logrus.Entry) func(http.Handler) http.Handler {
-	return func(h http.Handler) http.Handler {
-		entry := entry
-		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			if entry == nil {
-				return
-			}
-			start := time.Now()
-			body, err := readBody(req)
-			if err != nil {
-				entry.WithError(err)
-			}
-			statusRecorder := &responseRecorder{ResponseWriter: w}
-			h.ServeHTTP(statusRecorder, req)
-			elapsed := time.Since(start)
-			httpCode := statusRecorder.statusCode
-			entry = entry.WithFields(logrus.Fields{
-				"http_route":           req.URL.Path,
-				"http_method":          req.Method,
-				"http_code":            httpCode,
-				"elapsed_microseconds": elapsed.Microseconds(),
-			})
-			// only log full request/reposne data if running in debug mode
-			if entry.Logger.Level >= logrus.DebugLevel {
-				entry = entry.WithField("body", body)
-				entry = entry.WithField("response", string(statusRecorder.response))
-			}
-			if httpCode > 399 {
-				entry.Warn(req.URL.Path)
-			} else {
-				entry.Print(req.URL.Path)
-			}
+// logHTTPRequest provides logging middleware. It surfaces low level request/response data from the http server.
+func logHTTPRequest(entry *logrus.Entry, h http.Handler) http.Handler {
+	entry = entry
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if entry == nil {
+			return
+		}
+		start := time.Now()
+		body, err := readBody(req)
+		if err != nil {
+			entry.WithError(err)
+		}
+		statusRecorder := &responseRecorder{ResponseWriter: w}
+		h.ServeHTTP(statusRecorder, req)
+		elapsed := time.Since(start)
+		httpCode := statusRecorder.statusCode
+		entry = entry.WithFields(logrus.Fields{
+			"http_route":           req.URL.Path,
+			"http_method":          req.Method,
+			"http_code":            httpCode,
+			"elapsed_microseconds": elapsed.Microseconds(),
 		})
-	}
+		// only log full request/reposne data if running in debug mode
+		if entry.Logger.Level >= logrus.DebugLevel {
+			entry = entry.WithField("body", body)
+			entry = entry.WithField("response", string(statusRecorder.response))
+		}
+		if httpCode > 399 {
+			entry.Warn(req.URL.Path)
+		} else {
+			entry.Print(req.URL.Path)
+		}
+	})
 }
 
 type responseRecorder struct {

--- a/service/http.go
+++ b/service/http.go
@@ -96,7 +96,6 @@ func (a *API) Routes(l *logrus.Entry) *httprouter.Router {
 
 // logHTTPRequest provides logging middleware. It surfaces low level request/response data from the http server.
 func logHTTPRequest(entry *logrus.Entry, h http.Handler) http.Handler {
-	entry = entry
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		if entry == nil {
 			return


### PR DESCRIPTION
* Replaces http framework: [Gorilla Mux](https://github.com/gorilla/mux) --> [httprouter](https://github.com/julienschmidt/httprouter)
* Fixes broken benchmarks - read/write benchmark results shared below

## Reads

`main`
```
$ go test -benchmem -run=^$ -bench ^BenchmarkAccountRead
goos: linux
goarch: amd64
pkg: github.com/ATMackay/psql-ledger/integrationtests
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
BenchmarkAccountRead-20    	    1046	   1445850 ns/op	   17409 B/op	     107 allocs/op
PASS
ok  	github.com/ATMackay/psql-ledger/integrationtests	1.679s
```

`feat/httprouter`
```
$ go test -benchmem -run=^$ -bench ^BenchmarkAccountRead
goos: linux
goarch: amd64
pkg: github.com/ATMackay/psql-ledger/integrationtests
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
BenchmarkAccountRead-20    	    1215	   1304448 ns/op	   17407 B/op	     107 allocs/op
PASS
ok  	github.com/ATMackay/psql-ledger/integrationtests	1.742s

```

## Writes

`main`
```
$ go test -benchmem -run=^$ -bench ^BenchmarkAccountWrite
goos: linux
goarch: amd64
pkg: github.com/ATMackay/psql-ledger/integrationtests
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
BenchmarkAccountWrite-20    	     424	   2967765 ns/op	   16623 B/op	     107 allocs/op
PASS
ok  	github.com/ATMackay/psql-ledger/integrationtests	1.529s
```

`feat/httprouter`
```
$ go test -benchmem -run=^$ -bench ^BenchmarkAccountWrite
goos: linux
goarch: amd64
pkg: github.com/ATMackay/psql-ledger/integrationtests
cpu: 13th Gen Intel(R) Core(TM) i9-13900H
BenchmarkAccountWrite-20    	     486	   2570593 ns/op	   16516 B/op	     106 allocs/op
PASS
ok  	github.com/ATMackay/psql-ledger/integrationtests	2.569s

```